### PR TITLE
make_image: reshape tensor for Grayscale image

### DIFF
--- a/python/tensorboard/summary.py
+++ b/python/tensorboard/summary.py
@@ -164,7 +164,10 @@ def make_image(tensor):
     """Convert an numpy representation image to Image protobuf"""
     from PIL import Image
     height, width, channel = tensor.shape
-    image = Image.fromarray(tensor)
+    if channel == 1:
+        image = Image.fromarray(tensor.reshape(height, width))
+    else:
+        image = Image.fromarray(tensor)
     import io
     output = io.BytesIO()
     image.save(output, format='PNG')


### PR DESCRIPTION
PIL.fromarray function cannot handle channel==1.
TypeError has occurred.

```
from PIL import Image
import numpy as np
arr = np.random.rand(100,100,1)
image = Image.fromarray(arr)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/local/lib/python2.7/dist-packages/PIL/Image.py", line 2426, in fromarray
    raise TypeError("Cannot handle this data type")
TypeError: Cannot handle this data type
```

The tensor should be reshaped to 2D.

Signed-off-by: YujiOshima <yuji.oshima0x3fd@gmail.com>