### PR TITLE
Include wheel in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 numpy
+wheel


### PR DESCRIPTION
I noticed while building the package in a virtual environment that this package was needed by the following step in the install script:
`bash ./bazel-bin/tensorboard/tools/build_pip_package.sh ../python/dist/`
Otherwise, the following error occurred:
`error: invalid command 'bdist_wheel'`